### PR TITLE
Improve charts performance

### DIFF
--- a/src/pmfPlot/PmfPlot.tsx
+++ b/src/pmfPlot/PmfPlot.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react'
 import ReactEcharts from 'echarts-for-react'
+import { Opts } from 'echarts-for-react/lib/types'
 
 import { renderNumericValue } from '../helpers'
 import { transformSecondsToDate, renderItem, removeZeroData } from './helpers'
@@ -29,8 +30,8 @@ const PmfPlot = ({
   const highValues = values.map((item: any) => item.high)
   const maxValue = Math.max.apply(null, highValues)
 
-  const opts = useMemo(() => ({ renderer: 'svg' as 'svg' }), [])
-  const style = useMemo(() => ({ width, height }), [height, width])
+  const opts: Opts = { renderer: 'canvas' }
+  const style = { width, height }
 
   const pmfPlotData = (isDataSet ? data : [data])
     .map((dataSet: any, index: number) =>

--- a/src/profiler/__tests__/DataProfiler.test.tsx
+++ b/src/profiler/__tests__/DataProfiler.test.tsx
@@ -8,9 +8,19 @@ import { smallDataset } from '../__mocks__/ProfilerData.mock'
 import { Orient } from '../model'
 
 beforeAll(() => {
-  HTMLCanvasElement.prototype.getContext = jest.fn(
-    () => ({ measureText: jest.fn(() => ({ width: 100 })) } as any)
-  )
+  HTMLCanvasElement.prototype.getContext = jest.fn(() => {
+    const ctxMock = { measureText: jest.fn(() => ({ width: 100 })) }
+
+    // this mocks canvas api
+    return new Proxy(ctxMock, {
+      get: function (target, key, _) {
+        if (key in ctxMock) {
+          return Reflect.get(target, key)
+        }
+        return () => {}
+      },
+    }) as any
+  })
 })
 
 describe('Profiler', () => {

--- a/src/profiler/chart/__tests__/ChartAndTable.test.tsx
+++ b/src/profiler/chart/__tests__/ChartAndTable.test.tsx
@@ -6,9 +6,19 @@ import Chart from '../ChartAndTable'
 import { CheckedRowsContext, SizeContext } from '../../context'
 
 beforeAll(() => {
-  HTMLCanvasElement.prototype.getContext = jest.fn(
-    () => ({ measureText: jest.fn(() => ({ width: 100 })) } as any)
-  )
+  HTMLCanvasElement.prototype.getContext = jest.fn(() => {
+    const ctxMock = { measureText: jest.fn(() => ({ width: 100 })) }
+
+    // this mocks canvas api
+    return new Proxy(ctxMock, {
+      get: function (target, key, _) {
+        if (key in ctxMock) {
+          return Reflect.get(target, key)
+        }
+        return () => {}
+      },
+    }) as any
+  })
 })
 
 describe('Chart', () => {


### PR DESCRIPTION
Change rendering mode to `canvas` for echarts. This will visibly improve performance. The issue with ant table re-rendering however still persists