### PR TITLE
Update graph orientation

### DIFF
--- a/src/graph/DagNode.tsx
+++ b/src/graph/DagNode.tsx
@@ -22,14 +22,14 @@ export const DagNode = memo(
         {/* nowheel enables scrolling */}
         {sourcePosition === 'top' ? (
           <Handle
-            type="target"
+            type="source"
             position={Position['Top']}
             style={{ top: -3, background: '#555' }}
             isConnectable={isConnectable}
           />
         ) : (
           <Handle
-            type="target"
+            type="source"
             position={Position['Left']}
             style={{ left: -3, background: '#555', zIndex: 1 }}
             isConnectable={isConnectable}
@@ -50,14 +50,14 @@ export const DagNode = memo(
         </ScrollCard>
         {targetPosition === 'bottom' ? (
           <Handle
-            type="source"
+            type="target"
             position={Position['Bottom']}
             style={{ bottom: -3, background: '#555' }}
             isConnectable={isConnectable}
           />
         ) : (
           <Handle
-            type="source"
+            type="target"
             position={Position['Right']}
             style={{ right: -3, background: '#555' }}
             isConnectable={isConnectable}

--- a/src/graph/Graph.tsx
+++ b/src/graph/Graph.tsx
@@ -5,7 +5,7 @@ import { SearchArgs } from './SidebarSearch'
 import { Container, DrawerContainer, GraphContainer } from './styles'
 
 import ReactFlow, { Background, isNode, Node as Node0, Edge as Edge0 } from 'react-flow-renderer'
-import { Edge, Node, Graph, Highlight, Badge, Table, ChromaticScale } from './model'
+import { Edge, Node, Graph, Highlight, Badge, Table, ChromaticScale, Orientation } from './model'
 import { DagNode } from './DagNode'
 import { getLayoutedElements } from './layout'
 import {
@@ -119,7 +119,7 @@ const GraphComponent = ({ data, config: cfg }: Props) => {
       ?.tables?.find(table => table.name === drawerData?.name)
   }, [baseRelease, drawerData, data])
 
-  const elements = getLayoutedElements([...graph.nodes, ...graph.edges], config.layoutDirection)
+  const elements = getLayoutedElements([...graph.nodes, ...graph.edges], config.orientation)
   return (
     <Container>
       <Sidebar
@@ -177,7 +177,7 @@ interface Props {
 
 interface Config {
   current?: string
-  layoutDirection?: 'TB' | 'LR'
+  orientation?: Orientation
 
   // You can use any color scheme from https://github.com/d3/d3-scale-chromatic#sequential-single-hue
   // Pass the name of the scheme as chromaticScale prop (ex. 'interpolateBlues', 'interpolateGreens', etc.)
@@ -185,7 +185,7 @@ interface Config {
 }
 
 const defaultConfig: Required<Config> = {
-  layoutDirection: 'LR',
+  orientation: 'horizontal',
   chromaticScale: 'interpolatePuOr',
   current: '',
 }

--- a/src/graph/Sidebar.tsx
+++ b/src/graph/Sidebar.tsx
@@ -52,8 +52,8 @@ const Sidebar = ({
         <Radio.Group onChange={e => onHighlightChange(e.target.value)} value={highlight}>
           <Space direction="vertical">
             <Radio value={'nearest'}>Nearest</Radio>
-            <Radio value={'parents'}>Upstream (parents)</Radio>
-            <Radio value={'children'}>Downstream (children)</Radio>
+            <Radio value={'children'}>Upstream (children)</Radio>
+            <Radio value={'parents'}>Downstream (parents)</Radio>
           </Space>
         </Radio.Group>
       </SidebarContentWrapper>

--- a/src/graph/layout.ts
+++ b/src/graph/layout.ts
@@ -21,6 +21,7 @@ export const getLayoutedElements = (elements: Array<Node | Edge>, orientation: O
     align: 'DL',
     ranksep,
     nodesep,
+    ranker: 'longest-path',
   })
 
   elements.forEach(el => {

--- a/src/graph/layout.ts
+++ b/src/graph/layout.ts
@@ -1,6 +1,7 @@
 import { Edge, isNode, Node, Position } from 'react-flow-renderer'
 import dagre from 'dagre'
 import { NODE_HEIGHT, NODE_WIDTH } from './constants'
+import { Orientation } from './model'
 
 const nodeWidth = NODE_WIDTH
 const nodeHeight = NODE_HEIGHT
@@ -9,11 +10,12 @@ const nodesep = 16
 const startX = 48
 const startY = 32
 
-export const getLayoutedElements = (elements: Array<Node | Edge>, direction: 'LR' | 'TB') => {
+export const getLayoutedElements = (elements: Array<Node | Edge>, orientation: Orientation) => {
   const dagreGraph = new dagre.graphlib.Graph()
   dagreGraph.setDefaultEdgeLabel(() => ({}))
 
-  const isHorizontal = direction === 'LR'
+  const direction = orientation === 'horizontal' ? 'RL' : 'BT'
+  const isHorizontal = orientation === 'horizontal'
   dagreGraph.setGraph({
     rankdir: direction,
     align: 'DL',

--- a/src/graph/model.ts
+++ b/src/graph/model.ts
@@ -52,6 +52,8 @@ export interface Column {
   name: string
 }
 
+export type Orientation = 'horizontal' | 'vertical'
+
 type D3Scale =
   | 'interpolateBrBG'
   | 'interpolatePRGn'

--- a/stories/Graph.stories.tsx
+++ b/stories/Graph.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Story } from '@storybook/react'
-import { Graph as GraphComponent } from '../src'
+import GraphComponent from '../src/graph'
 
 import dataMock from './mocks/graph/dag_inlined.json'
 import diffDataMock1 from './mocks/graph/20210922_120415_152372/dag_inlined.json'
@@ -11,12 +11,18 @@ import grpcData from './mocks/graph/graph.bazel/grpc/dag.json'
 const Template: Story<any> = args => <GraphComponent {...args} />
 
 export const Graph = Template.bind({})
-Graph.storyName = 'Small data'
+Graph.storyName = 'sample data'
 Graph.args = {
   data: dataMock,
+}
+
+export const GraphVertical = Template.bind({})
+GraphVertical.storyName = 'sample data - vertical'
+GraphVertical.args = {
+  data: dataMock,
   config: {
-    chromaticScale: 'interpolatePuOr',
     orientation: 'vertical',
+    chromaticScale: 'interpolatePuOr',
   },
 }
 
@@ -24,18 +30,29 @@ export const DiffGraph = Template.bind({})
 DiffGraph.storyName = 'with diffing'
 DiffGraph.args = {
   data: [diffDataMock1, diffDataMock2] as any,
+  config: {
+    orientation: 'horizontal',
+  },
 }
 
 export const BigGraph = Template.bind({})
 BigGraph.storyName = 'lots of data - grpc'
 BigGraph.args = {
   data: grpcData,
+  config: {
+    orientation: 'horizontal',
+  },
 }
 
 export default {
   title: 'Chart/Graph',
   component: [Graph, DiffGraph, BigGraph],
-  parameters: {
-    layout: 'fullscreen',
+  argTypes: {
+    data: {
+      type: { required: true },
+    },
+    config: {
+      control: 'object',
+    },
   },
 }

--- a/stories/Graph.stories.tsx
+++ b/stories/Graph.stories.tsx
@@ -16,7 +16,7 @@ Graph.args = {
   data: dataMock,
   config: {
     chromaticScale: 'interpolatePuOr',
-    layoutDirection: 'TB',
+    orientation: 'vertical',
   },
 }
 


### PR DESCRIPTION
- Change default orientation to horizontal and is configurable
- Change the notion of upstream/downstream. Children are now upstream
- Change ranker to `longest-path`. It looks better to me so far for the larger graph. It pushes single nodes downwards
![Screenshot 2021-10-05 at 19 05 52](https://user-images.githubusercontent.com/9988008/136060770-c7da5fc4-de01-408b-a527-aef72adbeebc.png)
![Screenshot 2021-10-05 at 19 06 12](https://user-images.githubusercontent.com/9988008/136060783-4d0e9b31-928e-4e71-99f0-0802fdb306fd.png)

