### PR TITLE
Add spinner

### DIFF
--- a/src/graph/GraphComponent.tsx
+++ b/src/graph/GraphComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import ReactFlow, {
   ReactFlowProvider,
   Background,
@@ -14,6 +14,7 @@ import { DagEdge } from './components/DagEdge'
 
 import { ConnectedDrawer } from './components/ConnectedDrawer'
 import { DrawerTabs } from './components/DrawerTabs'
+import { Spinner } from './components/Spinner'
 
 import { graphLayout } from './graph-layout'
 import {
@@ -32,6 +33,8 @@ import { DataGraph, ChromaticScale, Orientation } from './model'
 import { mapInitialNodes, mapInitialEdges } from './graph-ops'
 
 const GraphComponent = ({ data, config: cfg }: Props) => {
+  const [isLoading, setIsLoading] = useState<boolean>(true)
+
   const validCurrentRelease =
     // check if the release specified in config is present in the data
     cfg?.currentRelease && !!data.find(dataItem => dataItem.version === cfg.currentRelease)
@@ -122,10 +125,12 @@ const GraphComponent = ({ data, config: cfg }: Props) => {
             nodeTypes={nodeTypes}
             edgeTypes={edgeTypes}
             elements={elements}
+            onLoad={() => setIsLoading(false)}
             onlyRenderVisibleElements={true}
             nodesConnectable={false}
             minZoom={0.2}
           >
+            <Spinner spinning={isLoading} />
             <Background />
           </ReactFlow>
         </ReactFlowProvider>

--- a/src/graph/components/Spinner.tsx
+++ b/src/graph/components/Spinner.tsx
@@ -1,0 +1,19 @@
+import React, { CSSProperties } from 'react'
+import Spin from 'antd/lib/spin'
+
+export const Spinner = ({ spinning }: Props) => (
+  <Spin style={style} size="large" tip="Loading..." spinning={spinning} />
+)
+
+interface Props {
+  spinning: boolean
+}
+
+const style: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  alignItems: 'center',
+  height: '100%',
+  width: '100%',
+}


### PR DESCRIPTION
<img width="979" alt="Screenshot 2021-11-10 at 18 12 22" src="https://user-images.githubusercontent.com/9988008/141150096-7a4f12be-2482-43b6-83cb-81676cdc6e7d.png">

Unfortunately, I don't find any way to add spinner delay (for small graphs). Until ReactFlow has loaded it is likely not possible to start the spinner timer unless some ref hacks